### PR TITLE
index/returnPayload: Fix undefined reference t

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -62,11 +62,11 @@ const main = async () => {
           content.includes(':LOGBOOK:') &&
           content.includes('collapsed:: true')
         ) {
-          const x = content.substring(char, t.content.indexOf(':LOGBOOK:'));
+          const x = content.substring(char, content.indexOf(':LOGBOOK:'));
 
-          return x.substring(char, t.content.indexOf('collapsed:: true'));
+          return x.substring(char, content.indexOf('collapsed:: true'));
         } else if (content.includes(':LOGBOOK:')) {
-          return content.substring(char, t.content.indexOf(':LOGBOOK:'));
+          return content.substring(char, content.indexOf(':LOGBOOK:'));
         } else if (content.includes('collapsed:: true')) {
           return content.substring(char, e.content.indexOf('collapsed:: true'));
         } else {


### PR DESCRIPTION
Following a prior refactor, the `returnPayload` function included
references to the variable `t` to access its contents, but that variable
is not defined in this scope.

This will result in the following error if used in TODO/DOING mode and a
LOGBOOK is available.

```
Uncaught (in promise) ReferenceError: t is not defined
    at o (index.js:86)
    at index.js:98
```

Fix the error by accessing the provided content variable directly.
